### PR TITLE
Ft return presigned url

### DIFF
--- a/image_service/apiv1/serializers.py
+++ b/image_service/apiv1/serializers.py
@@ -10,8 +10,9 @@ class PhotoSerializer(serializers.ModelSerializer):
         allow_empty_file=False,
         use_url=False
     )
+    signed_url = serializers.URLField(read_only=True)
 
     class Meta:
         model = models.Photo
-        fields = ('path', 'image')
+        fields = ('path', 'image', 'signed_url')
         read_only_fields = ('path',)

--- a/image_service/apiv1/tasks.py
+++ b/image_service/apiv1/tasks.py
@@ -8,18 +8,18 @@ from celery import shared_task
 from aws import s3
 
 
-async def async_upload_to_s3_wrapper(img, file_name):
+async def async_upload_to_s3_wrapper(img, file_name, content_type):
     ## TODO: Use of img.chunks() is preferred.
     binary_data = img.read()
     encoded = base64.b64encode(binary_data).decode()
-    async_upload_to_s3.delay(encoded, file_name)
+    async_upload_to_s3.delay(encoded, file_name, content_type)
 
 
 @shared_task
-def async_upload_to_s3(encoded, filename):
+def async_upload_to_s3(encoded, filename, content_type):
     decoded = base64.b64decode(encoded)
     sss = s3.S3Operations()
-    sss.upload_photo(decoded, filename)
+    sss.upload_photo(decoded, filename, content_type)
 
 
 @shared_task

--- a/image_service/apiv1/tasks.py
+++ b/image_service/apiv1/tasks.py
@@ -7,6 +7,9 @@ from celery import shared_task
 
 from aws import s3
 
+def generate_presigned_url(object_key):
+    sss = s3.S3Operations()
+    return sss.create_presigned_url(object_key)
 
 async def async_upload_to_s3_wrapper(img, file_name, content_type):
     ## TODO: Use of img.chunks() is preferred.

--- a/image_service/apiv1/viewsets.py
+++ b/image_service/apiv1/viewsets.py
@@ -24,7 +24,10 @@ class PhotoViewSet(viewsets.ModelViewSet):
             # (retrieve a user id from provided token.)
             photo.owner_id = int(random.random() * 100)
             photo.save()
-            asyncio.run(tasks.async_upload_to_s3_wrapper(img, file_name))
+            asyncio.run(
+                tasks.async_upload_to_s3_wrapper(
+                    img, file_name, img.content_type)
+            )
             return Response(
                 serializers.PhotoSerializer(photo).data,
                 status=status.HTTP_201_CREATED

--- a/image_service/apiv1/viewsets.py
+++ b/image_service/apiv1/viewsets.py
@@ -34,6 +34,17 @@ class PhotoViewSet(viewsets.ModelViewSet):
             )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    def list(self, request):
+        # directly modifying the contents of queryset will lead to unexpected
+        # behaviour. create a copy of queryset and modify that instead.
+        qset = self.queryset[::]
+        for photo in qset:
+            photo.signed_url = tasks.generate_presigned_url(photo.path)
+        return Response(
+            self.serializer_class(qset, many=True).data,
+            status=status.HTTP_200_OK
+        )
+
     def destroy(self, request, pk):
         try:
             # ---------------- TODO: add atomic transaction ---------------------

--- a/image_service/apiv1/viewsets.py
+++ b/image_service/apiv1/viewsets.py
@@ -15,7 +15,10 @@ class PhotoViewSet(viewsets.ModelViewSet):
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():
             img = request.data['image']
-            file_name = f'photos/{datetime.datetime.now()}-{img.name}'
+            fmt = "%Y_%m_%d__%H_%M_%S"
+            current_time = datetime.datetime.now()
+            formatted_time = datetime.datetime.strftime(current_time, fmt)
+            file_name = f'photos/{formatted_time}-{img.name}'
             photo = models.Photo(path=file_name)
             # TODO: To be fixed when authentication is done.
             # (retrieve a user id from provided token.)

--- a/image_service/aws/s3.py
+++ b/image_service/aws/s3.py
@@ -9,8 +9,11 @@ class S3Operations:
         bucket_name = os.environ['S3_BUCKET']
         self.bucket = self.s3_resource.Bucket(bucket_name)
 
-    def upload_photo(self, binary_data, filename):
-        self.bucket.put_object(Key=filename, Body=binary_data)
+    def upload_photo(self, binary_data, filename, content_type=None):
+        metadata = {}
+        if content_type:
+            metadata['Content-Type'] =  content_type
+        self.bucket.put_object(Key=filename, Body=binary_data, Metadata=metadata)
     
     def list_bucket_objects(self):
         count = 1

--- a/image_service/aws/s3.py
+++ b/image_service/aws/s3.py
@@ -1,6 +1,7 @@
 import os
 
 import boto3
+from botocore.exceptions import ClientError
 
 
 class S3Operations:
@@ -25,6 +26,22 @@ class S3Operations:
         bucket_name = os.environ['S3_BUCKET']
         s3_object = self.s3_resource.Object(bucket_name, object_key)
         s3_object.delete()
+
+    def create_presigned_url(self, object_key, expiration=3600):
+        s3_client = boto3.client('s3')
+        bucket_name = os.environ['S3_BUCKET']
+        try:
+            response = s3_client.generate_presigned_url('get_object',
+                Params={
+                    'Bucket': bucket_name,
+                    'Key': object_key,
+                    'ResponseContentType': 'image/jpeg; image/png'
+                },
+                ExpiresIn=expiration
+            )
+        except ClientError as ce:
+            return None
+        return response
 
     def __repr__(self):
         return f'<S3Operations: {os.environ["S3_BUCKET"]}>'

--- a/image_service/aws/s3.py
+++ b/image_service/aws/s3.py
@@ -5,9 +5,9 @@ import boto3
 
 class S3Operations:
     def __init__(self):
-        self.s3 = boto3.resource('s3')
+        self.s3_resource = boto3.resource('s3')
         bucket_name = os.environ['S3_BUCKET']
-        self.bucket = self.s3.Bucket(bucket_name)
+        self.bucket = self.s3_resource.Bucket(bucket_name)
 
     def upload_photo(self, binary_data, filename):
         self.bucket.put_object(Key=filename, Body=binary_data)
@@ -20,7 +20,7 @@ class S3Operations:
 
     def delete_bucket_object(self, object_key):
         bucket_name = os.environ['S3_BUCKET']
-        s3_object = self.s3.Object(bucket_name, object_key)
+        s3_object = self.s3_resource.Object(bucket_name, object_key)
         s3_object.delete()
 
     def __repr__(self):


### PR DESCRIPTION
- Generate an s3 presigned url that allows `GET` access to the s3 object for one hour.
- Create transient variable `signed_url` that will contain this generated url.