### PR TITLE
Fx optimize photo list endpoint

### DIFF
--- a/image_service/apiv1/models.py
+++ b/image_service/apiv1/models.py
@@ -1,10 +1,16 @@
 from django.db import models
 
+from apiv1 import tasks
+
 # Create your models here.
 class Photo(models.Model):
     photo_id = models.BigAutoField(primary_key=True)
     path = models.CharField(max_length=255)
     owner_id = models.PositiveBigIntegerField()
+
+
+    def get_signed_url(self):
+        return tasks.generate_presigned_url(self.path)
 
     def __repr__(self):
         return f'<Photo: {self.photo_id}>'

--- a/image_service/apiv1/serializers.py
+++ b/image_service/apiv1/serializers.py
@@ -10,7 +10,7 @@ class PhotoSerializer(serializers.ModelSerializer):
         allow_empty_file=False,
         use_url=False
     )
-    signed_url = serializers.URLField(read_only=True)
+    signed_url = serializers.URLField(read_only=True, source='get_signed_url')
 
     class Meta:
         model = models.Photo

--- a/image_service/apiv1/viewsets.py
+++ b/image_service/apiv1/viewsets.py
@@ -53,17 +53,6 @@ class PhotoViewSet(viewsets.ModelViewSet):
             )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def list(self, request):
-        # directly modifying the contents of queryset will lead to unexpected
-        # behaviour. create a copy of queryset and modify that instead.
-        qset = self.queryset[::]
-        for photo in qset:
-            photo.signed_url = tasks.generate_presigned_url(photo.path)
-        return Response(
-            self.serializer_class(qset, many=True).data,
-            status=status.HTTP_200_OK
-        )
-
     def destroy(self, request, pk):
         try:
             # ---------------- TODO: add atomic transaction ---------------------


### PR DESCRIPTION
- Create a `get_signed_url` method in the `Photo` model to generate pre-signed s3 urls.
- Use the `Photo` model's `get_signed_url` method to populate the `signed_url` attribute in the `PhotoSerializer`.
- Remove customised logic at the `photo-list` endpoint. It was primarily being used to attach signed urls to photo model instances but this is no longer required with the changes to the `Photo` model and` PhotoSerializer`.