### PR TITLE
Fix image service permissions

### DIFF
--- a/image_service/README.md
+++ b/image_service/README.md
@@ -9,7 +9,6 @@
 * AWS_ACCESS_KEY_ID
 * S3_BUCKET
 * CELERY_BROKER_URL
-* AUTH_SERVICE_URL
 
 ### Background Services
 The following background services are required to run the app.

--- a/image_service/apiv1/permissions.py
+++ b/image_service/apiv1/permissions.py
@@ -1,0 +1,18 @@
+from rest_framework import permissions, exceptions
+
+from apiv1 import utils
+
+class OnlyOwnerCanAccess(permissions.BasePermission):
+    def has_object_permission(self, request, view, object):
+        """
+        Restrict photo access to photo owners at `photo-detail` route.
+        """
+        current_user_id = request.headers.get('Owner-Id', None)
+        if not (utils.owner_id_header_is_valid(current_user_id)):
+            raise exceptions.NotAuthenticated(
+                'Invalid value for "Owner-Id" header.')
+        current_user_id = int(current_user_id)
+        if not (object.owner_id == current_user_id):
+            raise exceptions.PermissionDenied(
+                "Access to this resource is restricted to owner.")
+        return True

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -199,3 +199,21 @@ class TestPhotos(APITestCase):
         photos = models.Photo.objects.all()
         self.assertEqual(count - 1, len(photos))
         async_delete_object_from_s3.assert_called_once_with(random_photo.path)
+
+    def test_post_photo_no_owner_id_header(self):
+        """
+        Test the functionality to create photo entries when owner_id information
+        is not passed via the "Owner-Id" header.
+        """
+        # no photos exist yet
+        photos = models.Photo.objects.all()
+        self.assertEqual(len(photos), 0)
+        url = reverse('photo-list')
+        data = {
+            'image': self.get_uploaded_test_png()
+        }
+        response = self.client.post(url, data, format='multipart')
+        self.assertEqual(response.status_code, 401)
+        # assert photo has not been created
+        photos = models.Photo.objects.all()
+        self.assertEqual(len(photos), 0)

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -59,6 +59,12 @@ class TestPhotos(APITestCase):
         photo = SimpleUploadedFile('uploaded.png', photo.read(), content_type='multipart/form-data')
         return photo
 
+    def get_random_user_id(self):
+        """
+        Generates and returns a random user_id that falls between 1 - 1000.
+        """
+        return int(random.random() * 1000)
+
     @patch('apiv1.tasks.generate_presigned_url')
     @patch(
         'apiv1.utils.get_user_id_from_auth_service',

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -160,6 +160,10 @@ class TestPhotos(APITestCase):
 
     @patch('apiv1.tasks.generate_presigned_url')
     def test_put_photo(self, generate_presigned_url):
+        """
+        Validate that a user of current_user_id == photo.owner_id can edit
+        a photo of photo.owner_id == current_user_id
+        """
         current_user_id = self.get_random_user_id()
         _, photo_ids = self.generate_owner_fake_photo_entries(current_user_id)
         random_id = random.choice(photo_ids)
@@ -180,6 +184,10 @@ class TestPhotos(APITestCase):
 
     @patch('apiv1.tasks.async_delete_object_from_s3.delay')
     def test_delete_photo(self, async_delete_object_from_s3):
+        """
+        Validate that a user of current_user_id == photo.owner_id can delete
+        a photo of photo.owner_id == current_user_id
+        """
         current_user_id = self.get_random_user_id()
         count, photo_ids = self.generate_owner_fake_photo_entries(current_user_id)
         random_id = random.choice(photo_ids)

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -217,3 +217,25 @@ class TestPhotos(APITestCase):
         # assert photo has not been created
         photos = models.Photo.objects.all()
         self.assertEqual(len(photos), 0)
+
+    def test_post_photo_invalid_owner_id_header(self):
+        """
+        Test the functionality to create photo entries when "Owner-Id" header
+        contains invalid value.
+        Any value that cannot be converted to an int (to represent owner_id) is
+        considered invalid.
+        """
+        # no photos exist yet
+        photos = models.Photo.objects.all()
+        self.assertEqual(len(photos), 0)
+        url = reverse('photo-list')
+        data = {
+            'image': self.get_uploaded_test_png()
+        }
+        headers = {'Owner-Id': 'invalid header'}
+        response = self.client.post(
+            url, data, format='multipart', headers=headers)
+        self.assertEqual(response.status_code, 401)
+        # assert photo has not been created
+        photos = models.Photo.objects.all()
+        self.assertEqual(len(photos), 0)

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -142,11 +142,17 @@ class TestPhotos(APITestCase):
 
     @patch('apiv1.tasks.generate_presigned_url')
     def test_get_photo_detail(self, generate_presigned_url):
-        _, photo_ids = self.generate_random_fake_photo_entries()
+        """
+        Validate that a user of current_user_id == photo.owner_id can access
+        a photo of photo.owner_id == current_user_id
+        """
+        current_user_id = self.get_random_user_id()
+        _, photo_ids = self.generate_owner_fake_photo_entries(current_user_id)
         random_id = random.choice(photo_ids)
         random_photo = models.Photo.objects.get(pk=random_id)
         url = reverse('photo-detail', kwargs={'pk': random_id})
-        response = self.client.get(url)
+        headers = {'Owner-Id': current_user_id}
+        response = self.client.get(url, headers=headers)
         generate_presigned_url.assert_called_once()
         data = response.json()
         self.assertEqual(response.status_code, 200)

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -151,7 +151,7 @@ class TestPhotos(APITestCase):
         random_id = random.choice(photo_ids)
         random_photo = models.Photo.objects.get(pk=random_id)
         url = reverse('photo-detail', kwargs={'pk': random_id})
-        headers = {'Owner-Id': current_user_id}
+        headers = {'Owner-Id': f'{current_user_id}'}
         response = self.client.get(url, headers=headers)
         generate_presigned_url.assert_called_once()
         data = response.json()
@@ -172,7 +172,7 @@ class TestPhotos(APITestCase):
         new_data = {
             'image': self.get_uploaded_test_png()
         }
-        headers = {'Owner-Id': current_user_id}
+        headers = {'Owner-Id': f'{current_user_id}'}
         response = self.client.put(url, new_data, headers=headers)
         generate_presigned_url.assert_called_once()
         data = response.json()
@@ -193,7 +193,7 @@ class TestPhotos(APITestCase):
         random_id = random.choice(photo_ids)
         random_photo = models.Photo.objects.get(pk=random_id)
         url = reverse('photo-detail', kwargs={'pk': random_id})
-        headers = {'Owner-Id': current_user_id}
+        headers = {'Owner-Id': f'{current_user_id}'}
         response = self.client.delete(url, headers=headers)
         self.assertEqual(response.status_code, 204)
         photos = models.Photo.objects.all()

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -105,15 +105,16 @@ class TestPhotos(APITestCase):
         data = {
             'image': self.get_uploaded_test_png()
         }
-        self.client.credentials(HTTP_AUTHORIZATION='fake-auth-token')
-        response = self.client.post(url, data, format='multipart')
+        current_user_id = self.get_random_user_id()
+        headers = {'Owner-Id': f'{current_user_id}'}
+        response = self.client.post(
+            url, data, format='multipart', headers=headers)
         self.assertEqual(response.status_code, 202)
         # assert photo exists
         photos = models.Photo.objects.all()
         self.assertEqual(len(photos), 1)
         self.assertEqual(photos[0].path, response.json()['path'])
         async_wrapper.assert_called_once()
-        auth_service_handler.assert_called_once()
         generate_presigned_url.assert_called_once()
 
     @patch('apiv1.tasks.generate_presigned_url')

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -39,15 +39,40 @@ class TestPhotos(APITestCase):
         del self.client
         del self.fake
 
-    def generate_random_fake_photo_entries(self):
+    def generate_owner_fake_photo_entries(self, owner_id):
+        """
+        Generate random fake photo entries that belong to user of
+        user_id == owner_id.
+        """
         # create fake entries
         count = int(random.random() * 10) + 1
         photo_ids = []
         for i in range(count):
             data = {
                 'path': self.fake.file_name(),
-                'owner_id': int(random.random() * 1000)
+                'owner_id': owner_id
             }
+            photo = models.Photo(**data)
+            photo.save()
+            photo_ids.append(photo.photo_id)
+        return count, photo_ids
+
+    def generate_random_fake_photo_entries(self, owner_id):
+        """
+        Generates random fake photo entries that do not belong to user of
+        user_id == owner_id.
+        """
+        # create fake entries
+        count = int(random.random() * 10) + 1
+        photo_ids = []
+        for i in range(count):
+            data = {
+                'path': self.fake.file_name(),
+                'owner_id': self.get_random_user_id()
+            }
+            # ensure this photo entry does not belong to owner_id
+            while data['owner_id'] == owner_id:
+                data['owner_id'] = self.get_random_user_id()
             photo = models.Photo(**data)
             photo.save()
             photo_ids.append(photo.photo_id)

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -160,14 +160,16 @@ class TestPhotos(APITestCase):
 
     @patch('apiv1.tasks.generate_presigned_url')
     def test_put_photo(self, generate_presigned_url):
-        _, photo_ids = self.generate_random_fake_photo_entries()
+        current_user_id = self.get_random_user_id()
+        _, photo_ids = self.generate_owner_fake_photo_entries(current_user_id)
         random_id = random.choice(photo_ids)
         random_photo = models.Photo.objects.get(pk=random_id)
         url = reverse('photo-detail', kwargs={'pk': random_id})
         new_data = {
             'image': self.get_uploaded_test_png()
         }
-        response = self.client.put(url, new_data)
+        headers = {'Owner-Id': current_user_id}
+        response = self.client.put(url, new_data, headers=headers)
         generate_presigned_url.assert_called_once()
         data = response.json()
         self.assertEqual(response.status_code, 200)

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -180,11 +180,13 @@ class TestPhotos(APITestCase):
 
     @patch('apiv1.tasks.async_delete_object_from_s3.delay')
     def test_delete_photo(self, async_delete_object_from_s3):
-        count, photo_ids = self.generate_random_fake_photo_entries()
+        current_user_id = self.get_random_user_id()
+        count, photo_ids = self.generate_owner_fake_photo_entries(current_user_id)
         random_id = random.choice(photo_ids)
         random_photo = models.Photo.objects.get(pk=random_id)
         url = reverse('photo-detail', kwargs={'pk': random_id})
-        response = self.client.delete(url)
+        headers = {'Owner-Id': current_user_id}
+        response = self.client.delete(url, headers=headers)
         self.assertEqual(response.status_code, 204)
         photos = models.Photo.objects.all()
         self.assertEqual(count - 1, len(photos))

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -91,13 +91,9 @@ class TestPhotos(APITestCase):
         return int(random.random() * 1000)
 
     @patch('apiv1.tasks.generate_presigned_url')
-    @patch(
-        'apiv1.utils.get_user_id_from_auth_service',
-        return_value=MockUserServiceResponse()
-    )
     @patch('apiv1.tasks.async_upload_to_s3_wrapper')
     def test_post_photo(
-        self, async_wrapper, auth_service_handler, generate_presigned_url
+        self, async_wrapper, generate_presigned_url
     ):
         """
         Test photo create functionality.

--- a/image_service/apiv1/urls.py
+++ b/image_service/apiv1/urls.py
@@ -3,6 +3,6 @@ from rest_framework import routers
 from apiv1 import viewsets
 
 router = routers.SimpleRouter()
-router.register('photos', viewsets.PhotoViewSet)
+router.register('photos', viewsets.PhotoViewSet, basename='photo')
 
 urlpatterns = router.urls

--- a/image_service/apiv1/utils.py
+++ b/image_service/apiv1/utils.py
@@ -14,3 +14,16 @@ def get_user_id_from_auth_service(token):
     request = req.Request(url)
     request.add_header('Authorization', token)
     return req.urlopen(request)
+
+def owner_id_header_is_valid(owner_id):
+    """
+    Returns True of owner_id value is valid and returns False if otherwise.
+    """
+    if owner_id == None:
+        return False
+    for digit in owner_id:
+        try:
+            int(digit)
+        except ValueError:
+            return False
+    return True

--- a/image_service/apiv1/utils.py
+++ b/image_service/apiv1/utils.py
@@ -1,20 +1,3 @@
-import os
-from urllib import request as req
-
-def get_user_id_from_auth_service(token):
-    """
-    Takes in a token, sets it in the "Authorization" header and then sends a get
-    request to the auth service.
-    Returns the response from the auth service.
-    """
-    auth_service_url = os.environ['AUTH_SERVICE_URL']
-    endpoint = '/api/user/auth'
-    url = f'{auth_service_url}{endpoint}'
-    print(f'url: {url}')
-    request = req.Request(url)
-    request.add_header('Authorization', token)
-    return req.urlopen(request)
-
 def owner_id_header_is_valid(owner_id):
     """
     Returns True of owner_id value is valid and returns False if otherwise.

--- a/image_service/apiv1/viewsets.py
+++ b/image_service/apiv1/viewsets.py
@@ -49,7 +49,7 @@ class PhotoViewSet(viewsets.ModelViewSet):
     def destroy(self, request, pk):
         try:
             # ---------------- TODO: add atomic transaction ---------------------
-            photo_to_delete = self.queryset.get(pk=pk)
+            photo_to_delete = self.get_queryset().get(pk=pk)
             object_key = photo_to_delete.path
             photo_to_delete.delete()
             tasks.async_delete_object_from_s3.delay(object_key)

--- a/image_service/apiv1/viewsets.py
+++ b/image_service/apiv1/viewsets.py
@@ -8,9 +8,16 @@ from rest_framework.response import Response
 
 from apiv1 import models, serializers, tasks, utils
 
+
 class PhotoViewSet(viewsets.ModelViewSet):
-    queryset = models.Photo.objects.all()
     serializer_class = serializers.PhotoSerializer
+
+    def get_queryset(self):
+        owner_id = self.request.headers.get('Owner-Id', None)
+        if owner_id:
+            owner_id = int(owner_id)
+            return models.Photo.objects.filter(owner_id=owner_id)
+        return models.Photo.objects.none()
 
     def create(self, request):
         serializer = self.serializer_class(data=request.data)

--- a/image_service/apiv1/viewsets.py
+++ b/image_service/apiv1/viewsets.py
@@ -6,11 +6,18 @@ import random
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 
-from apiv1 import models, serializers, tasks, utils
+from apiv1 import (
+    models,
+    serializers,
+    tasks,
+    utils,
+    permissions as api_permissions
+)
 
 
 class PhotoViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.PhotoSerializer
+    permission_classes = [api_permissions.OnlyOwnerCanAccess]
 
     def get_queryset(self):
         owner_id = self.request.headers.get('Owner-Id', None)

--- a/image_service/apiv1/viewsets.py
+++ b/image_service/apiv1/viewsets.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import random
 
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 
@@ -25,6 +26,11 @@ class PhotoViewSet(viewsets.ModelViewSet):
             owner_id = int(owner_id)
             return models.Photo.objects.filter(owner_id=owner_id)
         return models.Photo.objects.none()
+
+    def get_object(self):
+        obj = models.Photo.objects.get(pk=self.kwargs['pk'])
+        self.check_object_permissions(self.request, obj)
+        return obj
 
     def create(self, request):
         serializer = self.serializer_class(data=request.data)

--- a/reverseproxy/template/template.conf
+++ b/reverseproxy/template/template.conf
@@ -6,8 +6,11 @@ server {
     }
 
     location /api/v1/ {
-        auth_jwt_key "${AUTH_JWT_KEY}";
+        auth_jwt_key $AUTH_JWT_KEY;
         auth_jwt_enabled on;
+        auth_jwt_extract_request_claims sub;
+        proxy_set_header Owner-Id http_jwt_sub;
+        proxy_set_header Host $host;
         proxy_pass  http://imageservice;
     }
 }

--- a/user_service/resources/auth.py
+++ b/user_service/resources/auth.py
@@ -42,7 +42,7 @@ class UserAuth(MethodResource, Resource):
             return {
                 'error': f'Invalid password for user {args["username"]}.'
             }, 401
-        access_token = create_access_token(identity=user.user_id)
+        access_token = create_access_token(identity=f'{user.user_id}')
         return {'access_token': access_token}, 200
 
     @doc(description='Get `username` of current authenticated request.')


### PR DESCRIPTION
Fixes #26 

- Fetch `owner_id` information from `Owner-Id` header which originates from nginx reverse proxy (in turn, this header's value originates from jwt which is validated at the reverse proxy).
- Update `test_photos.py` files to use `Owner-Id` headers and test CRUD operations on `Photos` owned by `owner_id`.
- Update CRUD operations in `PhotoViewset` to use new `get_queryset` function (replaces the `queryset` attribute).
- Update create `PhotoViewset` operation to use `Owner-Id` header in place of JWT.