### PR TITLE
Update test to compensate for datatype change in jwt `sub` (owner_id) claim.

### DIFF
--- a/user_service/tests/test_auth.py
+++ b/user_service/tests/test_auth.py
@@ -113,7 +113,8 @@ def test_identify_user_from_jwt_valid_authorization_header(
             headers={'Authorization': f'Bearer {token}'}
         )
         assert res.status_code == 200
-        assert res.json['user_id'] == existing_user.user_id
+        user_id = int(res.json['user_id'] )
+        assert user_id == existing_user.user_id
 
 def test_identify_user_from_jwt_invalid_authorization_header(client):
     """


### PR DESCRIPTION
- `owner_id` in jwt has string datatype because `ngx-http-auth-jwt-module` only works with string datatypes (not int).
- convert `owner_id` to int before testing equality against `user_id` field in the `User` model which is of type int.