### PR TITLE
Customize Put Photo Operation On Image Service

### DIFF
--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -383,3 +383,33 @@ class TestPhotos(APITestCase, UtilityHelpers):
         upload_to_s3.assert_not_called()
         self.assertEqual(response.status_code, 404)
 
+    @patch('apiv1.tasks.async_upload_to_s3_wrapper')
+    @patch('apiv1.tasks.async_delete_object_from_s3.s')
+    @patch('apiv1.tasks.generate_presigned_url')
+    def test_put_photo_transaction_failure(
+        self, generate_presigned_url, delete_from_s3, upload_to_s3
+    ):
+        """
+        Test that put operation does not succeed when transaction fails.
+        Photo should not be edited and corresponding changes to s3 should not
+        occur.
+        """
+        current_user_id = self.get_random_user_id()
+        count, photo_ids = self.generate_owner_fake_photo_entries(current_user_id)
+        # assert photos exist
+        photos = models.Photo.objects.all()
+        self.assertEqual(len(photos), count)
+        random_id = random.choice(photo_ids)
+        random_photo = models.Photo.objects.get(pk=random_id)
+        url = reverse('photo-detail', kwargs={'pk': random_id})
+        new_data = {
+            'image': self.get_uploaded_test_png()
+        }
+        headers = {'Owner-Id': f'{current_user_id}'}
+        with patch('apiv1.models.Photo.save', side_effect=IntegrityError):
+            response = self.client.put(url, new_data, headers=headers)
+            generate_presigned_url.assert_not_called()
+            delete_from_s3.assert_not_called()
+            upload_to_s3.assert_not_called()
+            self.assertEqual(response.status_code, 500)
+

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -413,3 +413,27 @@ class TestPhotos(APITestCase, UtilityHelpers):
             upload_to_s3.assert_not_called()
             self.assertEqual(response.status_code, 500)
 
+    @patch('apiv1.tasks.async_upload_to_s3_wrapper')
+    @patch('apiv1.tasks.async_delete_object_from_s3.s')
+    @patch('apiv1.tasks.generate_presigned_url')
+    def test_put_photo_missing_file_data(
+        self, generate_presigned_url, delete_from_s3, upload_to_s3
+    ):
+        """
+        Test put operation on photo when file data is missing.
+        """
+        current_user_id = self.get_random_user_id()
+        count, photo_ids = self.generate_owner_fake_photo_entries(current_user_id)
+        # assert photos exist
+        photos = models.Photo.objects.all()
+        self.assertEqual(len(photos), count)
+        random_id = random.choice(photo_ids)
+        random_photo = models.Photo.objects.get(pk=random_id)
+        url = reverse('photo-detail', kwargs={'pk': random_id})
+        new_data = {}
+        headers = {'Owner-Id': f'{current_user_id}'}
+        response = self.client.put(url, new_data, headers=headers)
+        generate_presigned_url.assert_not_called()
+        delete_from_s3.assert_not_called()
+        upload_to_s3.assert_not_called()
+        self.assertEqual(response.status_code, 400)

--- a/image_service/apiv1/tests/test_photos.py
+++ b/image_service/apiv1/tests/test_photos.py
@@ -177,7 +177,7 @@ class TestPhotos(APITestCase, UtilityHelpers):
         response = self.client.put(url, new_data, headers=headers)
         generate_presigned_url.assert_called_once()
         data = response.json()
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 202)
         # fetch updated data from db
         random_photo.refresh_from_db()
         # old data updated to new data
@@ -307,7 +307,6 @@ class TestPhotos(APITestCase, UtilityHelpers):
         headers = {'Owner-Id': f'{current_user_id}'}
         response = self.client.put(url, new_data, headers=headers)
         generate_presigned_url.assert_not_called()
-        data = response.json()
         self.assertEqual(response.status_code, 403)
 
     @patch('apiv1.tasks.async_delete_object_from_s3.delay')


### PR DESCRIPTION
- Upload to `s3` if and only if a successful update to the photo was made in the database.
-  Delete old photo from `s3` if and only if a successful update to the photo was made in the database.
- Add tests for customized `put` functionality.