### PR TITLE
Update/Fix template.conf values

### DIFF
--- a/reverseproxy/template/template.conf
+++ b/reverseproxy/template/template.conf
@@ -6,10 +6,11 @@ server {
     }
 
     location /api/v1/ {
+        client_max_body_size 10M;
         auth_jwt_key $AUTH_JWT_KEY;
         auth_jwt_enabled on;
         auth_jwt_extract_request_claims sub;
-        proxy_set_header Owner-Id http_jwt_sub;
+        proxy_set_header Owner-Id $http_jwt_sub;
         proxy_set_header Host $host;
         proxy_pass  http://imageservice;
     }


### PR DESCRIPTION
- Set client body size to 10MB to allow file uploads of up to 10MB from default 1MB.
- Fix typo that prevented "Owner-Id" header from containing the $http_jwt_sub variable value.