### PR TITLE
Ft Create Redis Connection Decorater

### DIFF
--- a/user_service/decorators/cache.py
+++ b/user_service/decorators/cache.py
@@ -1,0 +1,19 @@
+import functools
+import os
+import redis
+
+
+CACHE_CONNECTION = {}
+
+def get_redis_connection(func):
+    @functools.wraps(func)
+    def wrapper_redis_connection(*args, **kwargs):
+        if CACHE_CONNECTION.get('redis') == None:
+            CACHE_CONNECTION['redis'] = redis.Redis(
+                host=os.environ['REDIS_HOST'],
+                port=os.environ['REDIS_PORT'],
+                decode_responses=True
+            )
+        kwargs['redis_conn'] = kwargs.get('redis_conn', None) or CACHE_CONNECTION
+        return func(*args, **kwargs)
+    return wrapper_redis_connection

--- a/user_service/tests/fixtures/common.py
+++ b/user_service/tests/fixtures/common.py
@@ -48,16 +48,7 @@ def redis_mock(mocker):
 
         def set(self, key, val, ttl):
             self.data[key] = val
-
     cache = CacheDict()
-    def setter(key, value):
-        cache.set(key, value)
-    def getter(key):
-        if key == 'redis':
-            return cache
-        return cache.get(key)
-
     redis = mocker.patch('user_service.decorators.cache.CACHE_CONNECTION')
-    redis.set.side_effect = lambda key, value, exp: setter(key, value)
-    redis.get.side_effect = lambda key: getter(key)
+    redis.get.side_effect = lambda key: cache
     return redis


### PR DESCRIPTION
- Create a decorator that injects a `redis` connection to endpoints that require cache.
- Update endpoints to use `get_redis_connection` decorator.
- Update `redis_mock` to updated `redis` variable path.