### PR TITLE
Use sqlalchemy 2.0 query style

### DIFF
--- a/user_service/resources/auth.py
+++ b/user_service/resources/auth.py
@@ -6,7 +6,7 @@ from flask_jwt_extended import (
     get_jwt_identity
 )
 from flask_restful import reqparse, Resource
-from user_service.models import User as UserModel
+from user_service.models import User as UserModel, db
 from user_service.schemas.user import UserSchema, TokenSchema
 
 
@@ -27,7 +27,9 @@ class UserAuth(MethodResource, Resource):
         )
     
     def user_exists(self, username):
-        user = UserModel.query.filter_by(username=username).first()
+        user = db.session.scalar(
+            db.select(UserModel).where(UserModel.username==username)
+        )
         return user
 
     @doc(description='Authenticate a User with `username` and `password` details.')

--- a/user_service/resources/user.py
+++ b/user_service/resources/user.py
@@ -28,7 +28,9 @@ class User(MethodResource, Resource):
     @jwt_required()
     @is_owner
     def get(self, user_id):
-        user = UserModel.query.get(user_id)
+        user = db.session.scalar(
+            db.select(UserModel).where(UserModel.user_id==user_id)
+        )
         return UserSchema().dump(user), 200
 
 
@@ -39,7 +41,9 @@ class User(MethodResource, Resource):
     @is_owner
     def put(self, user_id, **kwargs):
         args = self.parser.parse_args()
-        user = UserModel.query.get(user_id)
+        user = db.session.scalar(
+            db.select(UserModel).where(UserModel.user_id==user_id)
+        )
         hashed_password = user.hash_password(args['password'])
         user.password = hashed_password or user.password
         db.session.add(user)
@@ -52,7 +56,9 @@ class User(MethodResource, Resource):
     @get_redis_connection
     @is_owner
     def delete(self, user_id, redis_conn=None):
-        user = UserModel.query.get(user_id)
+        user = db.session.scalar(
+            db.select(UserModel).where(UserModel.user_id==user_id)
+        )
         db.session.delete(user)
         db.session.commit()
         jti = get_jwt()['jti']
@@ -78,7 +84,9 @@ class UserList(MethodResource, Resource):
         )
 
     def user_exists(self, username):
-        user = UserModel.query.filter_by(username=username).first()
+        user = db.session.scalar(
+            db.select(UserModel).where(UserModel.username==username)
+        )
         return True if user else False
 
     @doc(description='Create a new user with `username` and `password` data.')

--- a/user_service/tests/test_auth.py
+++ b/user_service/tests/test_auth.py
@@ -147,7 +147,9 @@ def test_revoke_token_via_logout(client, credentials, redis_mock):
         })
         res = client.post(url, data=data, content_type='application/json')
         assert res.status_code == 201
-        created_users = models.User.query.all()
+        created_users = models.db.session.scalars(
+            models.db.select(models.User)
+        ).all()
         assert len(created_users) == 1
         url = url_for('user-auth')
         res = client.post(url, data=data, content_type='application/json')

--- a/user_service/tests/test_signup.py
+++ b/user_service/tests/test_signup.py
@@ -23,7 +23,11 @@ def test_signup(client, credentials):
         )
         assert res.status_code == 201
         # assert that user has been persisted in the database
-        saved_user = models.User.query.all()[0]
+        saved_user = models.db.session.scalars(
+            models.db.select(models.User)
+        ).all()
+        assert len(saved_user) == 1
+        saved_user = saved_user[0]
         assert saved_user.username == credentials['username']
         # assert that the password has not been persisted in plain-text form
         assert saved_user.password != credentials['password']
@@ -39,7 +43,9 @@ def test_signup_missing_username(client):
             url, data=json.dumps(data), content_type='application/json')
         assert res.status_code == 400
         # assert that database has remained unchanged
-        saved_user = models.User.query.all()
+        saved_user = models.db.session.scalars(
+            models.db.select(models.User)
+        ).all()
         assert len(saved_user) == 0
 
 
@@ -53,7 +59,9 @@ def test_signup_missing_password(client):
             url, data=json.dumps(data), content_type='application/json')
         assert res.status_code == 400
         # assert that database has remained unchanged
-        saved_user = models.User.query.all()
+        saved_user = models.db.session.scalars(
+            models.db.select(models.User)
+        ).all()
         assert len(saved_user) == 0
 
 
@@ -68,7 +76,9 @@ def test_signup_missing_username_and_password(client):
             url, data=json.dumps(data), content_type='application/json')
         assert res.status_code == 422
         # assert that database has remained unchanged
-        saved_user = models.User.query.all()
+        saved_user = models.db.session.scalars(
+            models.db.select(models.User)
+        ).all()
         assert len(saved_user) == 0
 
 

--- a/user_service/tests/test_user_details.py
+++ b/user_service/tests/test_user_details.py
@@ -55,7 +55,11 @@ def test_delete_user(client, logged_in_user, redis_mock):
         url = url_for('user-detail', user_id=user.user_id)
         res = client.delete(url, headers={'Authorization': f'Bearer {token}'})
         assert res.status_code == 204
-        user_in_db = models.User.query.get(user.user_id)
+        user_in_db = models.db.session.scalar(
+            models.db.select(models.User).where(
+                models.User.user_id==user.user_id
+            )
+        )
         assert user_in_db == None
 
 
@@ -82,7 +86,11 @@ def test_edit_user_details(client, logged_in_user, redis_mock):
             headers={'Authorization': f'Bearer {token}'}
         )
         assert res.status_code == 200
-        user_in_db = models.User.query.get(user.user_id)
+        user_in_db = models.db.session.scalar(
+            models.db.select(models.User).where(
+                models.User.user_id==user.user_id
+            )
+        )
         # assert that the password in the data dictionary above is the new
         # password
         assert user_in_db.verify_password(data['password']) is True


### PR DESCRIPTION
- Update `sqlalchemy` queries to 2.0 recommended style. 
- Older style is deprecated and will be removed in future releases.