### PR TITLE
Fix Delete User When Multiple Valid JWTs exist

### DIFF
--- a/user_service/resources/user.py
+++ b/user_service/resources/user.py
@@ -59,12 +59,14 @@ class User(MethodResource, Resource):
         user = db.session.scalar(
             db.select(UserModel).where(UserModel.user_id==user_id)
         )
-        db.session.delete(user)
-        db.session.commit()
-        jti = get_jwt()['jti']
-        ttl = current_app.config['JWT_ACCESS_TOKEN_EXPIRES']
-        redis_conn.get('redis').set(jti, jti, ttl)
-        return '', 204
+        if user:
+            db.session.delete(user)
+            db.session.commit()
+            jti = get_jwt()['jti']
+            ttl = current_app.config['JWT_ACCESS_TOKEN_EXPIRES']
+            redis_conn.get('redis').set(jti, jti, ttl)
+            return '', 204
+        return {'error': 'User not found'}, 404
 
 
 class UserList(MethodResource, Resource):


### PR DESCRIPTION
- Handle edge case where a single user could have multiple valid and non-blacklisted JWTs, which would allow them to perform the delete user operation more than once.
- This PR addresses the symptom, the root cause is #53 