### PR TITLE
Fix rate limit decorator

### DIFF
--- a/user_service/app.py
+++ b/user_service/app.py
@@ -17,7 +17,7 @@ from flask_limiter.util import get_remote_address
 from user_service.resources.user import User as UserResource, UserList
 from user_service.resources.auth import UserAuth
 from user_service.decorators.cache import get_redis_connection
-from user_service.decorators.rate_limiter import jwt_limiter
+from user_service.decorators.rate_limiter import rate_limit
 
 
 def create_app(test_config=False):
@@ -82,7 +82,7 @@ def create_app(test_config=False):
 
     @app.route('/api/token/refresh', methods=['POST'])
     @jwt_required(refresh=True)
-    @jwt_limiter
+    @rate_limit('2/15 minutes')
     def refresh():
         identity = get_jwt_identity()
         access_token = create_access_token(identity=identity)

--- a/user_service/decorators/rate_limiter.py
+++ b/user_service/decorators/rate_limiter.py
@@ -3,17 +3,11 @@ import functools
 from flask import g
 
 
-def jwt_limiter(func):
-    @functools.wraps(func)
-    def wrapper_jwt_limiter(*args, **kwargs):
-        # TODO: Rate limit is currently hard coded. Ideal solution would be to
-        # pass in the rate limit as a string argument to this decorator.
-        # However, accepting multiple arguments (changing jwt_limiter signature
-        # to jwt_limiter(*func)) will cause the decorator to run outside the
-        # flask application context.
-        # This means that we will not be able to access attributes inside the
-        # "g" namespace (where the limiter has been stored.)
-        # The `with g.limiter.limit` line below will result to a RuntimeError
-        with g.limiter.limit('2/15 minutes'):
-            return func(*args, **kwargs)
-    return wrapper_jwt_limiter
+def rate_limit(limit):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper_decorator(*args, **kwargs):
+            with g.limiter.limit(limit):
+                return func(*args, **kwargs)
+        return wrapper_decorator
+    return decorator

--- a/user_service/resources/auth.py
+++ b/user_service/resources/auth.py
@@ -9,7 +9,7 @@ from flask_jwt_extended import (
 from flask_restful import reqparse, Resource
 from user_service.models import User as UserModel, db
 from user_service.schemas.user import UserSchema, TokenSchema
-from user_service.decorators.rate_limiter import jwt_limiter
+from user_service.decorators.rate_limiter import rate_limit
 
 
 class UserAuth(MethodResource, Resource):
@@ -37,7 +37,7 @@ class UserAuth(MethodResource, Resource):
     @doc(description='Authenticate a User with `username` and `password` details.')
     @use_kwargs(UserSchema, location=('json'))
     @marshal_with(TokenSchema, code=200)
-    @jwt_limiter
+    @rate_limit('2/15 minutes')
     def post(self, **kwargs):
         args = self.parser.parse_args()
         user = self.user_exists(args['username'])


### PR DESCRIPTION
- Update `rate_limiter` (formerly `jwt_limiter`) decorator to allow arguments.